### PR TITLE
Add Jenkins pipeline files in jenkins/ folder

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,38 @@
+pipeline {
+    agent any
+    triggers {
+        pollSCM('H/5 * * * *')
+    }
+    options {
+        preserveStashes(buildCount: 5)
+    }
+    stages {
+        stage('Unit Tests') {
+            when { branch 'main' }
+            steps {
+                script {
+                    build job: 'unit-tests', wait: true, propagate: true
+                }
+            }
+        }
+        stage('Integration Tests') {
+            when { branch 'main' }
+            steps {
+                script {
+                    build job: 'integration-tests', wait: true, propagate: true
+                }
+            }
+        }
+        stage('API Tests') {
+            when { branch 'main' }
+            steps {
+                script {
+                    build job: 'api-tests', wait: true, propagate: true
+                }
+            }
+        }
+    }
+    post {
+        always { cleanWs() }
+    }
+}

--- a/jenkins/Jenkinsfile.api
+++ b/jenkins/Jenkinsfile.api
@@ -1,0 +1,14 @@
+pipeline {
+    agent { label 'linux' }
+    stages {
+        stage('Checkout') { steps { checkout scm } }
+        stage('Run API Isolated Tests') { steps { sh './gradlew apiIsolatedTests' } }
+        stage('Publish API Test Results') {
+            steps {
+                archiveArtifacts artifacts: '**/build/test-results/apiIsolatedTests/*.xml', allowEmptyArchive: true, fingerprint: true
+                junit testResults: '**/build/test-results/apiIsolatedTests/*.xml', allowEmptyResults: true, skipPublishingChecks: false
+            }
+        }
+    }
+    post { always { cleanWs() } }
+}

--- a/jenkins/Jenkinsfile.integration
+++ b/jenkins/Jenkinsfile.integration
@@ -1,0 +1,14 @@
+pipeline {
+    agent { label 'linux' }
+    stages {
+        stage('Checkout') { steps { checkout scm } }
+        stage('Run Integration Tests') { steps { sh './gradlew integrationTests' } }
+        stage('Publish Integration Test Results') {
+            steps {
+                archiveArtifacts artifacts: '**/build/test-results/integrationTests/*.xml', allowEmptyArchive: true, fingerprint: true
+                junit testResults: '**/build/test-results/integrationTests/*.xml', allowEmptyResults: true, skipPublishingChecks: false
+            }
+        }
+    }
+    post { always { cleanWs() } }
+}

--- a/jenkins/Jenkinsfile.unit
+++ b/jenkins/Jenkinsfile.unit
@@ -1,0 +1,14 @@
+pipeline {
+    agent { label 'linux' }
+    stages {
+        stage('Checkout') { steps { checkout scm } }
+        stage('Build & Run Unit Tests') { steps { sh './gradlew clean build' } }
+        stage('Publish Unit Test Results') {
+            steps {
+                archiveArtifacts artifacts: '**/build/test-results/test/*.xml', allowEmptyArchive: true, fingerprint: true
+                junit testResults: '**/build/test-results/test/*.xml', allowEmptyResults: true, skipPublishingChecks: false
+            }
+        }
+    }
+    post { always { cleanWs() } }
+}


### PR DESCRIPTION
This PR introduces Jenkins pipeline files, converted from existing GitHub Actions workflows. The following files have been added under the new jenkins/ directory:

- Jenkinsfile (aggregate pipeline)
- Jenkinsfile.unit
- Jenkinsfile.integration
- Jenkinsfile.api

These scripts provide equivalent CI/CD functionality to the original GitHub Actions setup, supporting unit, integration, and API testing as well as pipeline aggregation.