### PR TITLE
Convert Jenkins pipelines to Azure DevOps

### DIFF
--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -1,0 +1,54 @@
+# Jenkins to Azure DevOps Pipeline Conversion
+
+This directory contains Azure DevOps pipeline definitions converted from the original Jenkins pipeline files.
+
+## Pipeline Files
+
+1. **unit-pipeline.yml**: Converted from `Jenkinsfile.unit`
+   - Runs unit tests with Gradle
+   - Publishes JUnit test results
+
+2. **integration-pipeline.yml**: Converted from `Jenkinsfile.integration`
+   - Runs integration tests with Gradle
+   - Publishes JUnit test results
+
+3. **api-pipeline.yml**: Converted from `Jenkinsfile.api`
+   - Runs API isolated tests with Gradle
+   - Publishes JUnit test results
+
+4. **aggregate-pipeline.yml**: Converted from `Jenkinsfile.aggregate`
+   - Orchestrates the other three pipelines in sequence
+   - Uses Azure DevOps stages and dependencies to create the sequential flow
+
+## Implementation Notes
+
+1. **Agent Specification**: 
+   - Jenkins used `agent any` which means "use any available agent"
+   - In Azure DevOps, we specified `ubuntu-latest` as the agent pool, but you may need to adjust this based on your Azure DevOps setup
+
+2. **Pipeline Triggering**:
+   - The individual pipelines (unit, integration, api) are set with `trigger: none` as they will be called by the aggregate pipeline
+   - The aggregate pipeline is set to trigger on changes to the main branch
+
+3. **Pipeline Dependencies**:
+   - Jenkins used the `build job` step to trigger other pipelines and wait for completion
+   - In Azure DevOps, we use stages with dependencies to create the same sequential flow
+
+4. **Test Results Publishing**:
+   - Jenkins used the `junit` step in the `post` section
+   - Azure DevOps uses the `PublishTestResults@2` task with `condition: always()` to ensure it runs regardless of test success/failure
+
+5. **Templates vs. Inline Steps**:
+   - The aggregate pipeline example uses templates for modularity
+   - You could also inline all steps if you prefer a single file approach
+
+## Usage
+
+To use these pipelines in Azure DevOps:
+
+1. Create a new pipeline in Azure DevOps
+2. Select "Existing Azure Pipelines YAML file"
+3. Select the `aggregate-pipeline.yml` file
+4. Run the pipeline
+
+The aggregate pipeline will automatically run the unit, integration, and API tests in sequence.

--- a/azure-pipelines/aggregate-pipeline.yml
+++ b/azure-pipelines/aggregate-pipeline.yml
@@ -1,0 +1,39 @@
+# Converted from Jenkinsfile.aggregate
+# Azure DevOps Aggregate Pipeline
+
+trigger:
+  branches:
+    include:
+    - main  # Standard trigger on main branch
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+- stage: UnitTests
+  displayName: 'Build & Unit Tests'
+  jobs:
+  - job: UnitTestsJob
+    steps:
+    # In Azure DevOps, we can either:
+    # 1. Use template reference (recommended for modularity)
+    # 2. Inline the steps from unit-pipeline.yml
+    # Option 1 with template:
+    - template: unit-pipeline.yml
+    # Option 2 would be to inline all steps here
+
+- stage: IntegrationTests
+  displayName: 'Integration Tests'
+  dependsOn: UnitTests  # This creates the sequential flow
+  jobs:
+  - job: IntegrationTestsJob
+    steps:
+    - template: integration-pipeline.yml
+
+- stage: APITests
+  displayName: 'API Isolated Tests'
+  dependsOn: IntegrationTests  # This creates the sequential flow
+  jobs:
+  - job: APITestsJob
+    steps:
+    - template: api-pipeline.yml

--- a/azure-pipelines/api-pipeline.yml
+++ b/azure-pipelines/api-pipeline.yml
@@ -1,0 +1,23 @@
+# Converted from Jenkinsfile.api
+# Azure DevOps Pipeline for API Isolated Tests
+
+trigger: none  # This will be triggered by the aggregate pipeline
+
+pool:
+  vmImage: 'ubuntu-latest'  # Using a standard Azure DevOps agent
+
+steps:
+- task: Bash@3
+  displayName: 'Run API Isolated Tests'
+  inputs:
+    targetType: 'inline'
+    script: './gradlew apiIsolatedTests'
+
+- task: PublishTestResults@2
+  displayName: 'Publish API Test Results'
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '**/build/test-results/apiIsolatedTests/*.xml'
+    mergeTestResults: true
+    testRunTitle: 'API Isolated Tests'
+  condition: always()  # Equivalent to Jenkins 'post { always { ... } }'

--- a/azure-pipelines/integration-pipeline.yml
+++ b/azure-pipelines/integration-pipeline.yml
@@ -1,0 +1,23 @@
+# Converted from Jenkinsfile.integration
+# Azure DevOps Pipeline for Integration Tests
+
+trigger: none  # This will be triggered by the aggregate pipeline
+
+pool:
+  vmImage: 'ubuntu-latest'  # Using a standard Azure DevOps agent
+
+steps:
+- task: Bash@3
+  displayName: 'Run Integration Tests'
+  inputs:
+    targetType: 'inline'
+    script: './gradlew integrationTests'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Integration Test Results'
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '**/build/test-results/integrationTests/*.xml'
+    mergeTestResults: true
+    testRunTitle: 'Integration Tests'
+  condition: always()  # Equivalent to Jenkins 'post { always { ... } }'

--- a/azure-pipelines/unit-pipeline.yml
+++ b/azure-pipelines/unit-pipeline.yml
@@ -1,0 +1,23 @@
+# Converted from Jenkinsfile.unit
+# Azure DevOps Pipeline for Unit Tests
+
+trigger: none  # This will be triggered by the aggregate pipeline
+
+pool:
+  vmImage: 'ubuntu-latest'  # Using a standard Azure DevOps agent
+
+steps:
+- task: Bash@3
+  displayName: 'Build & Run Unit Tests'
+  inputs:
+    targetType: 'inline'
+    script: './gradlew clean build'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Unit Test Results'
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '**/build/test-results/test/*.xml'
+    mergeTestResults: true
+    testRunTitle: 'Unit Tests'
+  condition: always()  # Equivalent to Jenkins 'post { always { ... } }'


### PR DESCRIPTION
This PR converts the existing Jenkins pipeline files to Azure DevOps YAML pipeline format.

## Converted Files
- `Jenkinsfile.unit` → `azure-pipelines/unit-pipeline.yml`
- `Jenkinsfile.integration` → `azure-pipelines/integration-pipeline.yml`
- `Jenkinsfile.api` → `azure-pipelines/api-pipeline.yml`
- `Jenkinsfile.aggregate` → `azure-pipelines/aggregate-pipeline.yml`

## Implementation Details
- Used Azure DevOps YAML pipeline syntax
- Maintained the same functionality as the original Jenkins pipelines
- Used templates for modularity
- Added detailed README with implementation notes

The converted pipelines maintain the same workflow:
1. Run unit tests
2. Run integration tests
3. Run API isolated tests

Each pipeline publishes test results in the same way as the original Jenkins pipelines.