### PR TITLE
Convert Jenkins pipelines to GitHub Actions workflows

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -1,19 +1,23 @@
-# .github/workflows/aggregate.yml
 name: Aggregate Pipeline
 
 on:
   push:
-    branches: [main]
-  workflow_dispatch:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:  # Allows manual triggering
 
 jobs:
-  unit:
+  # Call unit test workflow
+  unit-tests:
     uses: ./.github/workflows/unit.yml
 
-  integration:
-    needs: unit
+  # Call integration test workflow (depends on unit tests)
+  integration-tests:
+    needs: unit-tests
     uses: ./.github/workflows/integration.yml
 
-  api:
-    needs: integration
+  # Call API test workflow (depends on integration tests)
+  api-tests:
+    needs: integration-tests
     uses: ./.github/workflows/api.yml

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,17 +1,30 @@
-# .github/workflows/api.yml
 name: API Isolated Tests
 
-on: [workflow_call]
+on:
+  workflow_call:  # This workflow can be called by other workflows
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
-  api:
+  api-tests:
     runs-on: ubuntu-latest
+    
     steps:
-      - uses: actions/checkout@v3
-      - name: Run API Isolated Tests
-        run: ./gradlew apiIsolatedTests
-      - name: Publish API Test Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: api-test-results
-          path: '**/build/test-results/apiIsolatedTests/*.xml'
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'  # Using a reasonable default - adjust as needed
+        distribution: 'temurin'
+        
+    - name: Run API Isolated Tests
+      run: ./gradlew apiIsolatedTests
+      
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()  # Run this step even if the previous step fails
+      with:
+        files: '**/build/test-results/apiIsolatedTests/*.xml'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,17 +1,30 @@
-# .github/workflows/integration.yml
 name: Integration Tests
 
-on: [workflow_call]
+on:
+  workflow_call:  # This workflow can be called by other workflows
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
-  integration:
+  integration-tests:
     runs-on: ubuntu-latest
+    
     steps:
-      - uses: actions/checkout@v3
-      - name: Run Integration Tests
-        run: ./gradlew integrationTests
-      - name: Publish Integration Test Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-test-results
-          path: '**/build/test-results/integrationTests/*.xml'
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'  # Using a reasonable default - adjust as needed
+        distribution: 'temurin'
+        
+    - name: Run Integration Tests
+      run: ./gradlew integrationTests
+      
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()  # Run this step even if the previous step fails
+      with:
+        files: '**/build/test-results/integrationTests/*.xml'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,17 +1,30 @@
-# .github/workflows/unit.yml
 name: Build & Unit Tests
 
-on: [workflow_call]
+on:
+  workflow_call:  # This workflow can be called by other workflows
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
-  unit:
+  unit-tests:
     runs-on: ubuntu-latest
+    
     steps:
-      - uses: actions/checkout@v3
-      - name: Build & Run Unit Tests
-        run: ./gradlew clean build
-      - name: Publish Unit Test Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-results
-          path: '**/build/test-results/test/*.xml'
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'  # Using a reasonable default - adjust as needed
+        distribution: 'temurin'
+        
+    - name: Build & Run Unit Tests
+      run: ./gradlew clean build
+      
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()  # Run this step even if the previous step fails
+      with:
+        files: '**/build/test-results/test/*.xml'


### PR DESCRIPTION
This PR converts the Jenkins pipelines (Jenkinsfile.aggregate, Jenkinsfile.api, Jenkinsfile.integration, Jenkinsfile.unit) into GitHub Actions workflows, organized under .github/workflows/ and aligned with best practices.

Changes included:
- Added/Updated workflows:
  - .github/workflows/unit.yml: Builds project and runs unit tests; publishes results.
  - .github/workflows/integration.yml: Runs integration tests; publishes results.
  - .github/workflows/api.yml: Runs API isolated tests; publishes results.
  - .github/workflows/aggregate.yml: Orchestrates unit -> integration -> api using reusable workflows and dependencies.

Notes:
- Uses actions/setup-java@v3 with Java 17 (Temurin). Adjust if your project requires a different JDK.
- Each individual workflow is reusable via `workflow_call`, and can also be triggered on push/PR to main.
- Test results are published using EnricoMi/publish-unit-test-result-action@v2.

No other code changes are included.