### PR TITLE
Convert Jenkins pipelines to GitHub Actions workflows (branch: test-jg)

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,32 @@
+name: API Isolated Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  api-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        
+    - name: Run API isolated tests
+      run: ./gradlew apiIsolatedTests
+      
+    - name: Archive test results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: api-test-results
+        path: "**/build/test-results/apiIsolatedTests/*.xml"
+        retention-days: 5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,32 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        
+    - name: Run integration tests
+      run: ./gradlew integrationTests
+      
+    - name: Archive test results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: integration-test-results
+        path: "**/build/test-results/integrationTests/*.xml"
+        retention-days: 5

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-unit-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        
+    - name: Build and run unit tests
+      run: ./gradlew clean build
+      
+    - name: Archive test results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: unit-test-results
+        path: "**/build/test-results/test/*.xml"
+        retention-days: 5


### PR DESCRIPTION
This PR adds GitHub Actions workflows converted from the Jenkins pipelines:

- .github/workflows/api-tests.yml

Notes:
- Test result publishing uses actions/upload-artifact to avoid permission issues.
- Workflows are organized under .github/workflows following GitHub best practices.

Input CI/CD System: Jenkins
Target CI/CD System: GitHub (Actions)

Please review the converted workflow. If additional adjustments are needed (e.g., Java version, triggers, or artifact retention), let me know and I will update accordingly.