### PR TITLE
Add aggregate GitHub Actions workflow and ensure all workflows present

### DIFF
--- a/.github/workflows/aggregate-pipeline.yml
+++ b/.github/workflows/aggregate-pipeline.yml
@@ -1,0 +1,23 @@
+name: Aggregate Tests Pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit:
+    name: Build & Unit Tests
+    uses: ./.github/workflows/unit.yml
+
+  integration:
+    name: Integration Tests
+    needs: unit
+    uses: ./.github/workflows/integration.yml
+
+  api:
+    name: API Isolated Tests
+    needs: integration
+    uses: ./.github/workflows/api.yml


### PR DESCRIPTION
This PR adds the missing aggregate pipeline workflow converted from Jenkinsfile.aggregate and ensures all converted GitHub Actions workflows are present.

Added:
- .github/workflows/aggregate-pipeline.yml

Existing reusable workflows referenced:
- .github/workflows/unit.yml
- .github/workflows/integration.yml
- .github/workflows/api.yml

Notes:
- Triggers added to aggregate workflow for push, PR, and manual dispatch.
- Each child workflow is called via `uses` and preserves Jenkins stage ordering with `needs`.
- Test results are uploaded as artifacts to avoid permissions issues with check runs.

Please review.